### PR TITLE
Fixed rules not working correctly on int values

### DIFF
--- a/locommon.py
+++ b/locommon.py
@@ -305,7 +305,7 @@ class ExcludeRule(object):
             return self.calculate_book_should_be_moved(book, self.get_start_field_data(book, field), self.value)
 
         else:
-            return self.calculate_book_should_be_moved(book, getattr(book, field), self.value)
+            return self.calculate_book_should_be_moved(book, unicode(getattr(book, field)), self.value)
     
 
     def calculate_book_should_be_moved(self, book, field_data, value):


### PR DESCRIPTION
Fields that are int types like Volume don't work with is, is not and crash with contains, not contains. Since the value set in the plugin is (probably) always a string, converting the field_data to a string (or unicode to prevent char like Japanese to crash). This way contains should also work correctly.

When encountering a rule with greater than and less than, the existing code should take care to convert back to an int already.