### PR TITLE
Dark Mode support

### DIFF
--- a/configureform.py
+++ b/configureform.py
@@ -45,6 +45,8 @@ from loforms import NewIllegalCharacterDialog, GetProfileNameDialog
 
 from locommon import SCRIPTDIRECTORY, ICON, check_excluded_folders, check_metadata_rules, get_custom_value_keys
 
+from locommon import ThemeMe, get_toolstrip_renderer
+
 import losettings
 
 from losettings import Profile
@@ -323,7 +325,7 @@ class ConfigureForm(Form):
         self._toolstrip.Location = System.Drawing.Point(0, 0)
         self._toolstrip.Name = "toolstrip"
         self._toolstrip.Padding = System.Windows.Forms.Padding(10)
-        self._toolstrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.System
+        self._toolstrip.Renderer = get_toolstrip_renderer()
         self._toolstrip.ShowItemToolTips = False
         self._toolstrip.Size = System.Drawing.Size(130, 462)
         self._toolstrip.TabIndex = 0
@@ -2121,6 +2123,7 @@ class ConfigureForm(Form):
         sender.Tag.Visible = True
         
         self.update_template_text()
+        ThemeMe(self)
 
         self.ResumeLayout()
         
@@ -2216,6 +2219,7 @@ class ConfigureForm(Form):
     def add_illegal_character(self, sender, e):
         """Adds a new character replacement into the form and profile"""
         dialog = NewIllegalCharacterDialog(self.profile.IllegalCharacters.keys())
+        ThemeMe(dialog)
 
         result = dialog.ShowDialog()
 
@@ -2324,6 +2328,7 @@ class ConfigureForm(Form):
                 self.create_calculated_insert_controls()
             self._calculated_insert_controls.Controls.Clear()
 
+        ThemeMe(self)
         self._insert_controls.ResumeLayout()
 
 
@@ -2789,6 +2794,7 @@ class ConfigureForm(Form):
 
         Returns the new name or None if the user canceled the dialog"""
         profile_name_dialog = GetProfileNameDialog(self.profiles.keys(), label_text, existing_name)
+        ThemeMe(profile_name_dialog)
 
         dialog_result = profile_name_dialog.ShowDialog()
 

--- a/libraryorganizer.py
+++ b/libraryorganizer.py
@@ -137,6 +137,7 @@ def LibraryOrganizerUndo(books):
 
             if len(undo_collection) > 0:
                 undo_form = WorkerFormUndo(undo_collection, profiles)
+                locommon.ThemeMe(undo_form)
                 undo_form.ShowDialog()
                 undo_form.Dispose()
                 File.Delete(UNDOFILE)
@@ -164,6 +165,7 @@ def show_config_form(profiles, lastused, books):
     Returns True if the user press Okay.
     Returns False if the user pressed cancel."""
     configform = ConfigureForm(profiles, lastused[0], books)
+    locommon.ThemeMe(configform)
     result = configform.ShowDialog()
     configform.save_profile()
     configform.Dispose()
@@ -177,6 +179,7 @@ def show_worker_form(profiles, lastused, books):
     """Gets the profile(s) to use and shows the worker form."""
     if len(profiles) > 1:
         profile_selector = ProfileSelector(profiles.keys(), lastused)
+        locommon.ThemeMe(profile_selector)
         result = profile_selector.ShowDialog()
         if result == DialogResult.Cancel:
             profile_selector.Dispose()
@@ -188,4 +191,5 @@ def show_worker_form(profiles, lastused, books):
     profiles_to_use = [profiles[name] for name in lastused]
 
     worker_form = WorkerForm(books, profiles_to_use)
+    locommon.ThemeMe(worker_form)
     worker_form.ShowDialog()

--- a/lobookmover.py
+++ b/lobookmover.py
@@ -709,6 +709,7 @@ class BookMover(object):
     def get_smaller_path(self, path):
 
         p = PathTooLongForm(path)
+        locommon.ThemeMe(p)
         r = p.ShowDialog()
 
         if r != DialogResult.OK:

--- a/locommon.py
+++ b/locommon.py
@@ -649,3 +649,25 @@ def get_custom_value_keys():
             if pair.Key not in keys:
                 keys.append(pair.Key)
     return keys
+
+def ThemeMe(control):
+    """Applies the current theme applied to ComicRack
+    
+    Requires version 0.9.182
+    """
+    if ComicRack.App.ProductVersion >= '0.9.182':
+        ComicRack.Theme.ApplyTheme(control)
+
+def get_toolstrip_renderer():
+    """Returns a ToolStripRenderer depending of CR versions.
+    
+    Higher or equal than 0.9.182, will use Theme.ToolStripRenderer
+    Else it will use the ToolStripSystemRenderer
+    
+    Not even sure why we are even changing this (for backwards compatibility). 
+    It would have used the same if we didn't change this or left RenderMode eq. ManagerRenderMode
+    """
+    if ComicRack.App.ProductVersion >= '0.9.182':
+        return ComicRack.Theme.ToolStripRenderer # The ToolStripRenderer will return a system renderer when Dark Mode is disabled
+    else:
+        return System.Windows.Forms.ToolStripSystemRenderer

--- a/locommon.py
+++ b/locommon.py
@@ -670,4 +670,4 @@ def get_toolstrip_renderer():
     if ComicRack.App.ProductVersion >= '0.9.182':
         return ComicRack.Theme.ToolStripRenderer # The ToolStripRenderer will return a system renderer when Dark Mode is disabled
     else:
-        return System.Windows.Forms.ToolStripSystemRenderer
+        return System.Windows.Forms.ToolStripSystemRenderer()

--- a/loworkerform.py
+++ b/loworkerform.py
@@ -39,7 +39,7 @@ from System.Windows.Forms import *
 import loduplicate
 from loduplicate import DuplicateForm
 
-from locommon import ICON, Mode
+from locommon import ICON, Mode, ThemeMe
 
 from lobookmover import BookMover, UndoMover
 
@@ -173,6 +173,7 @@ class WorkerForm(Form):
         """Shows the report form with the available logger."""
         report = loforms.ReportForm()
         report.LoadData(self.logger.ToArray())
+        ThemeMe(report)
         r = report.ShowDialog()
         if r == DialogResult.Yes:
             self.logger.SaveLog()


### PR DESCRIPTION
Added support for Dark Mode in ComicRack Community Edition. https://github.com/maforget/ComicRackCE/issues/2

- Uses `ComicRack.Theme.ApplyTheme` on `Form` and `Control`, available in v0.9.182 and higher.
- It also provides a `ToolStripRenderer` that will be properly themed.

Although that last one was only needed because the `ToolStrip.RenderMode` was set previously. Making `ToolStripButton` have a dark background when running un-themed in dark mode, when they were supposed to be light. I didn't want to change functionality for user not running the latest ComicRackCE. ~~But it would have done pretty much the same thing to not change any `Renderer` / `RenderMode` in the first place.~~ No it was required, because if it wasn't changed it would have been worse when running un-themed in dark mode.

**Known Issue:**
- The result screen will remain in light mode because it's a `MessageBox`. 
- Also didn't touch the XAML. I wouldn't touch that with our IThemePlugin interfaces.


Before:
<img width="641" height="494" alt="Screenshot 2025-10-24 141945" src="https://github.com/user-attachments/assets/65cf83b4-99af-45d6-8498-d0bef7fe19b8" />

After:
<img width="641" height="494" alt="Screenshot 2025-10-29 023310" src="https://github.com/user-attachments/assets/27a4076d-5f33-4b7e-8acd-80b98eaf71f0" />

Without System Renderer:
<img width="641" height="494" alt="Screenshot 2025-10-29 000730" src="https://github.com/user-attachments/assets/dc31f792-a6c8-49ad-9fcf-69da3a669409" />

There is a link to a test build of ComicRackCE available here that has Dark Mode support: https://github.com/maforget/ComicRackCE/pull/212
Requires a `ComicRack.ini` tweak to enable, see [Wiki ](https://github.com/maforget/ComicRackCE/wiki/Dark-Mode#how-to-enable-it)
